### PR TITLE
fix idle timeout issue

### DIFF
--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -288,14 +288,15 @@ function handleHTTPStream (fnfunction, options) {
   }
 
   let currentServer = http.createServer(functionHandler)
-    .listen(tmpFile, () => {
-      fs.chmodSync(tmpFile, '666')
-      fs.symlinkSync(tmpFileBaseName, listenFile)
-    })
-    .on('error', (error) => {
-      console.warn(`Unable to connect to unix socket ${tmpFile}`, error)
-      process.exit(3)
-    })
+  currentServer.keepAliveTimeout = 0 // turn off
+  currentServer.listen(tmpFile, () => {
+    fs.chmodSync(tmpFile, '666')
+    fs.symlinkSync(tmpFileBaseName, listenFile)
+  })
+  currentServer.on('error', (error) => {
+    console.warn(`Unable to connect to unix socket ${tmpFile}`, error)
+    process.exit(3)
+  })
 
   return () => {
     currentServer.close()


### PR DESCRIPTION
details of bug are here: https://github.com/nodejs/node/issues/13391
docs here: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_server_keepalivetimeout

tl;dr is node set a 5s idle timeout. this does what go and java both seem to
do (have not checked python or ruby, though from what I know about python,
we are not doing this either) and doesn't have an idle timeout. since in this
case we do kinda trust that the client is using an idle timeout (it's fn),
this seems like the right policy anyway (if fn dies is something to consider,
but the least of our worries is fdk conns in that case, and we are killing fn
spawned containers on startup too). it should also be noted the client (fn) is
only using 1 conn per container.