### PR TITLE
add fn-fdk-version to node fdk

### DIFF
--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -5,6 +5,8 @@
 const fs = require('fs')
 const http = require('http')
 const path = require('path')
+const version = require('./package.json')
+const fdkVersion = 'fdk-node/' + version.version + ' (njsv=' + process.version + ')'
 
 const fnFunctionExceptionMessage = 'Exception in function, consult logs for details'
 
@@ -135,6 +137,7 @@ function sendResult (ctx, resp, result) {
     }
   }
   resp.removeHeader('Content-length')
+  resp.setHeader('Fn-Fdk-Version', fdkVersion)
   resp.writeHead(200, 'OK')
 
   let p
@@ -304,8 +307,10 @@ function handleHTTPStream (fnfunction, options) {
   currentServer.keepAliveTimeout = 0 // turn off
   currentServer.listen(tmpFile, () => {
     fs.chmodSync(tmpFile, '666')
+
     fs.symlinkSync(tmpFileBaseName, listenFile)
   })
+
   currentServer.on('error', (error) => {
     console.warn(`Unable to connect to unix socket ${tmpFile}`, error)
     process.exit(3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fnproject/fdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/fn-fdk-test.js
+++ b/test/fn-fdk-test.js
@@ -173,6 +173,7 @@ test('Listens and accepts request', function (t) {
         t.equals(r.body, 'done')
         t.equals(r.resp.headers['fn-http-h-my-out-header'], 'out')
         t.equals(r.resp.headers['fn-http-status'], '302')
+        t.match(r.resp.headers['fn-fdk-version'], /fdk-node\/\d+\.\d+\.\d+ \(njsv=v\d+.\d+.\d+\)/)
         t.end()
       })
     })


### PR DESCRIPTION
This adds an Fn-Fdk-Version header to outbound responses 

```
Connected to localhost (::1) port 8080 (#0)
> POST /invoke/01E3AFDFKGNG8G00GZJ0000001 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Length: 0
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 200 OK
< Content-Length: 25
< Content-Type: application/json
< Date: Fri, 13 Mar 2020 17:47:47 GMT
< Fn-Call-Id: 01E3AG4R61NG8G00GZJ000000G
< Fn-Fdk-Version: fdk-node/0.0.16 (njsv=v11.15.0)
< 
* Connection #0 to host localhost left intact
{"message":"Hello World"}%  
```