### PR TITLE
Add tests to http context, fix issue with headers not being populated

### DIFF
--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -272,9 +272,17 @@ function handleHTTPStream (fnfunction, options) {
 
         const v = rawHeaders[i + 1]
         if (headers[k] == null) {
-          headers[k] = [v]
+          if (Array.isArray(v)) {
+            headers[k] = v.slice()
+          } else {
+            headers[k] = [v]
+          }
         } else {
-          headers[k].push(v)
+          if (Array.isArray(v)) {
+            headers[k] = headers[k].concat(v)
+          } else {
+            headers[k].push(v)
+          }
         }
       }
 
@@ -375,7 +383,7 @@ class HTTPGatewayContext {
     const headers = {}
     for (const k in this._headers) {
       if (Object.prototype.hasOwnProperty.call(this._headers, k)) {
-        headers[k] = new Array(this._headers[k])
+        headers[k] = this._headers[k].slice()
       }
     }
     return headers
@@ -534,8 +542,14 @@ class Context {
   get headers () {
     const headers = {}
     for (const k in this._headers) {
-      if (Object.prototype.hasOwnProperty.call(this._headers.hasOwnProperty, k)) {
-        headers[k] = new Array(this._headers[k])
+      if (Object.prototype.hasOwnProperty.call(this._headers, k)) {
+        let value = this._headers[k]
+        if (!Array.isArray(value)) {
+          value = new Array(value)
+        } else {
+          value = value.slice()
+        }
+        headers[k] = value
       }
     }
     return headers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fnproject/fdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The previous security changes broke HTTP header handling, resuling in httpGateway.headers being empty , this fixes that and adds a test for the httpGateway behavior: 

Prior to this change, an error in the Context Creation caused `ctx.headers` and `ctx.httpGateway.headers` to be empty rather than containing the passed headers. 


Here is an example node function that echos the incoming context to verify: 
```
const fdk=require('@fnproject/fdk');

fdk.handle((input,ctx)=>{

    const hctx = ctx.httpGateway;
    hctx.setResponseHeader("my-header",["foo","bar"])
    hctx.statusCode = 202
    return { "ctx":{
                "headers" : ctx.headers,
                "config" : ctx.config,
                "body":  ctx.body
             },
             "hctx":{
                    "headers": hctx.headers,
                    "request_url" : hctx.requestUrl,
                    "method": hctx.method
             }
     }
});

```

and here is a call with this change applied: 
```
fdk-node git:(oc/FixHttpHeaderHandling) ✗ curl -XPOST -HMy-Header:v1 -Hmy-Header:v1 -Hfoo:bar -v  https://m4qidvydq267ftgmjcuy2hmqw4.apigateway.us-ashburn-1.oci.customer-oci.com/ | jq

> POST / HTTP/1.1
> Host:  mygateway.com
> User-Agent: curl/7.54.0
> Accept: */*
> My-Header:v1
> my-Header:v1
> foo:bar
>
< HTTP/1.1 202 Accepted
< Date: Tue, 28 Apr 2020 01:09:46 GMT
< Content-Type: application/json
< Connection: keep-alive
< Content-Length: 2251
< Server: Oracle API Gateway
< Strict-Transport-Security: max-age=31536000
< X-XSS-Protection: 1; mode=block
< X-Frame-Options: sameorigin
< My-Header: foo
< My-Header: bar
< X-Content-Type-Options: nosniff
<
{ [2251 bytes data]
100  2251  100  2251    0     0   3157      0 --:--:-- --:--:-- --:--:--  3157
* Connection #0 to host mygateway.com left intact
{
  "ctx": {
    "headers": {
      "Host": [
        "localhost"
      ],
      "User-Agent": [
        "my-user-agent"
      ],
      "Content-Type": [
        "application/octet-stream"
      ],
      "Date": [
        "Tue, 28 Apr 2020 01:09:46 GMT"
      ],
      "Fn-Call-Id": [
        "01E6Z5AC1C1BT0J7RZJ00191WG"
      ],
      "Fn-Deadline": [
        "2020-04-28T01:10:16Z"
      ],
      "Fn-Http-H-Accept": [
        "*/*"
      ],
      "Fn-Http-H-Content-Type": [
        "application/octet-stream"
      ],
      "Fn-Http-H-Foo": [
        "bar"
      ],
      "Fn-Http-H-Forwarded": [
        "for=1.2.3.4"
      ],
      "Fn-Http-H-Host": [
        "mygateway.com"
      ],
      "Fn-Http-H-My-Header": [
        "v1",
        "v1"
      ],
      "Fn-Http-H-User-Agent": [
        "curl/7.54.0"
      ],
      "Fn-Http-H-X-Forwarded-For": [
        "160.34.126.70"
      ],
      "Fn-Http-H-X-Real-Ip": [
        "160.34.126.70"
      ],
      "Fn-Http-Method": [
        "POST"
      ],
      "Fn-Http-Request-Url": [
        "/"
      ],
      "Fn-Intent": [
        "httprequest"
      ],
      "Fn-Invoke-Type": [
        "sync"
      ],
      "X-Content-Sha256": [
        "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
      ],
      "Accept-Encoding": [
        "gzip"
      ]
    },
    "config": {
      "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "HOSTNAME": "5ee5027fcda7",
      "FN_CPUS": "50m",
      "FN_FN_ID": "ocid1.fnfunc.oc1.iad.fnid",
      "FN_MEMORY": "128",
      "FN_TYPE": "sync",
      "FN_LISTENER": "unix:/tmp/iofs/lsnr.sock",
      "FN_FORMAT": "http-stream",
      "FN_APP_ID": "ocid1.fnapp.oc1.iad.appid",
      "NODE_VERSION": "11.15.0",
      "YARN_VERSION": "1.15.2",
      "HOME": "/home/fn"
    },
    "body": ""
  },
  "hctx": {
    "headers": {
      "Accept": [
        "*/*"
      ],
      "Content-Type": [
        "application/octet-stream"
      ],
      "Foo": [
        "bar"
      ],
      "Forwarded": [
        "for=1.2.3.4"
      ],
      "Host": [
        "gatewayhost.com"
      ],
      "My-Header": [
        "v1",
        "v1"
      ],
      "User-Agent": [
        "curl/7.54.0"
      ],
      "X-Forwarded-For": [
        "1.2.3.4"
      ],
      "X-Real-Ip": [
        "1.2.3.4"
      ]
    },
    "method": "POST"
  }
}
```