### PR TITLE
Add support for Oracle Cloud Infrastructure tracing solution by providing a tracing context

### DIFF
--- a/examples/tracing-basic/func.js
+++ b/examples/tracing-basic/func.js
@@ -215,5 +215,5 @@ function createOCISampler (ctx) {
 function getServiceName (ctx) {
   const appName = (ctx.appName) ? ctx.appName : 'oci-fn-app'
   const fnName = (ctx.fnName) ? ctx.fnName : 'oci-fn-node-fdk'
-  return appName + ':' + fnName
+  return (appName + '::' + fnName).toLowerCase()
 }

--- a/examples/tracing-basic/func.js
+++ b/examples/tracing-basic/func.js
@@ -1,132 +1,132 @@
-const fdk=require('@fnproject/fdk');
+const fdk = require('@fnproject/fdk')
 
 // ZipkinJS core components.
-const { 
-  ExplicitContext, 
-  Tracer, 
-  TraceId, 
-  BatchRecorder, 
-  jsonEncoder, 
-  sampler, 
+const {
+  ExplicitContext,
+  Tracer,
+  TraceId,
+  BatchRecorder,
+  jsonEncoder,
+  sampler,
   option
-} = require('zipkin');
+} = require('zipkin')
 
 // An HTTP transport for dispatching Zipkin traces.
-const {HttpLogger} = require('zipkin-transport-http');
+const { HttpLogger } = require('zipkin-transport-http')
 
-fdk.handle(async function(input, ctx){
-  tracer = createOCITracer(ctx);
+fdk.handle(async function (input, ctx) {
+  var tracer = createOCITracer(ctx)
 
-  var result;
+  var result
   // Start a new 'scoped' server handling span.
   await tracer.scoped(async function () {
     // Fetch some resource
     result = await tracer.local('fetchResource', () => {
-      return fetchResource();
-    });
+      return fetchResource()
+    })
     // Perform some processing
     result = await tracer.local('processResource', () => {
-      return someComputation(result);
-    });
+      return someComputation(result)
+    })
     // Update some resource
     result = await tracer.local('updateResource', () => {
-      return updateResource(result);
-    });
-    await flush();
-  }); 
+      return updateResource(result)
+    })
+    await flush()
+  })
 
-  return result;
-
+  return result
 })
 
 // ----------------------------------------------------------------------------
-// App Simulation Functions 
+// App Simulation Functions
 //
 
 /**
  * Simulate fetching some required resource. This could be another OCI service
  * or an external call.
- * 
+ *
  * @returns A Promise with the success or failure of the operation.
  */
- function fetchResource() {
-  return simulate(1000, {fetchResource: "OK"});
+function fetchResource () {
+  return simulate(1000, { fetchResource: 'OK' })
 }
 
 /**
  * Simulate some work. This could be another OCI service.
- * 
+ *
  * @returns A Promise with the success or failure of the operation.
  */
-async function someComputation(toReturn) {
+async function someComputation (toReturn) {
+  var i
   for (i = 0; i < 5; i++) {
-    await simulate(1000);
-  } 
-  toReturn["processResource"] = "OK";
-  return toReturn;
+    await simulate(1000)
+  }
+  toReturn.processResource = 'OK'
+  return toReturn
 }
 
 /**
- * Simulate updating some resource. This could be another OCI service or an 
+ * Simulate updating some resource. This could be another OCI service or an
  * external call.
- * 
+ *
  * @returns A Promise with the success or failure of the operation.
  */
-async function updateResource(toReturn) {
-  await simulate(500);
-  toReturn["updateResource"] = "OK";
-  return toReturn;
+async function updateResource (toReturn) {
+  await simulate(500)
+  toReturn.updateResource = 'OK'
+  return toReturn
 }
 
 /**
  * A helper function to simulate an operation that takes a specified amount of time.
- * 
+ *
  * @param {*} ms The simulated time for the activity in milliseconds.
  * @returns      A promise that resolves when the simulated activity finishes.
  */
-function simulate(ms, result) {
-  return new Promise(resolve => setTimeout(resolve, ms, result));
+function simulate (ms, result) {
+  return new Promise(resolve => setTimeout(resolve, ms, result))
 }
 
 /**
  * Functions service may freeze or terminate the container on completion.
  * This function gives extra time to allow the runtime to flush any pending traces.
  * See: https://github.com/openzipkin/zipkin-js/issues/507
- * 
+ *
  * @returns A Promise to await on.
  */
-function flush() {
-  return new Promise(resolve => setTimeout(resolve, 1000));
+function flush () {
+  return new Promise(resolve => setTimeout(resolve, 1000))
 }
 
 // ----------------------------------------------------------------------------
-// OpenZipkin ZipkinJS Utility Functions 
+// OpenZipkin ZipkinJS Utility Functions
 //
 
 /**
- * Creates a basic Zipkin Tracer using values from context of the function 
+ * Creates a basic Zipkin Tracer using values from context of the function
  * invocation.
- * 
+ *
  * @param {*} ctx The function invocation context.
  * @returns       A configured Tracer for automatically tracing calls.
  */
- function createOCITracer(ctx) {
-  const serviceName = getServiceName(ctx);
+function createOCITracer (ctx) {
+  const serviceName = getServiceName(ctx)
 
   // An OCI APM configured Tracer
   //
-  const traceCxt = ctx.traceContext;
+  const traceCxt = ctx.traceContext
   const tracer = new Tracer({
     ctxImpl: new ExplicitContext(),
     recorder: new BatchRecorder({
       logger: new HttpLogger({
-        // The configured OCI APM endpoint is available in the function 
+        // The configured OCI APM endpoint is available in the function
         // invocation context.
         endpoint: traceCxt.traceCollectorUrl,
         jsonEncoder: jsonEncoder.JSON_V2
-      }),
+      })
     }),
-    // APM Dimensions that should be included in all traces can be configured 
+    // APM Dimensions that should be included in all traces can be configured
     // directly on Tracer.
     defaultTags: createOCITags(ctx),
     // A custom sampling strategy can be defined.
@@ -134,24 +134,24 @@ function flush() {
     localServiceName: serviceName,
     supportsJoin: true,
     traceId128Bit: true
-  });
+  })
 
   // The initial function invocation trace identifiers can be added directly.
   // If this is not defined a default TraceId is created.
-  const traceId = createOCITraceId(tracer, ctx);
-  tracer.setId(traceId);
-  return tracer;
+  const traceId = createOCITraceId(tracer, ctx)
+  tracer.setId(traceId)
+  return tracer
 }
 
 /**
- * A ZipkinJS 'TraceId' can be created directly from the function invocation 
+ * A ZipkinJS 'TraceId' can be created directly from the function invocation
  * context.
- * 
+ *
  * @param {*} ctx The function invocation context.
  * @returns       A ZipkinJS 'TraceId' created from the invocation context.
  */
-function createOCITraceId(tracer, ctx) {
-  const traceCxt = ctx.traceContext;
+function createOCITraceId (tracer, ctx) {
+  const traceCxt = ctx.traceContext
   if (traceCxt.traceId && traceCxt.spanId) {
     return new TraceId({
       traceId: traceCxt.traceId,
@@ -159,61 +159,61 @@ function createOCITraceId(tracer, ctx) {
       sampled: new option.Some(traceCxt.sampled),
       debug: new option.Some(traceCxt.debug),
       shared: false
-    });
+    })
   } else {
     return tracer.createRootId(
       new option.Some(traceCxt.sampled),
       new option.Some(traceCxt.debug)
-    );
+    )
   }
 }
 
 /**
- * A ZipkinJS 'TraceId' can be crated directly from the function invocation 
+ * A ZipkinJS 'TraceId' can be crated directly from the function invocation
  * context.
- * 
+ *
  * This configurations will automatically add the function meta-data as APM
  * dimensions to each trace. Function environment variable and other dimensions
  * could also be added.
- * 
+ *
  * @param {*} ctx The function invocation context.
- * @returns       A map of key-value pairs, that will be added as APM 
+ * @returns       A map of key-value pairs, that will be added as APM
  *                dimensions to the traces.
  */
-function createOCITags(ctx) {
+function createOCITags (ctx) {
   return {
-    "appID": ctx.appID,
-    "appName": ctx.appName,
-    "fnID": ctx.fnID,
-    "fnName": ctx.fnName,
+    appID: ctx.appID,
+    appName: ctx.appName,
+    fnID: ctx.fnID,
+    fnName: ctx.fnName
   }
 }
 
 /**
- * A ZipkinJS 'Sampler' can be created directly from the function invocation 
- * context. 
- * 
- * This configuration will only create a trace if both the function and the 
+ * A ZipkinJS 'Sampler' can be created directly from the function invocation
+ * context.
+ *
+ * This configuration will only create a trace if both the function and the
  * Zipkin Sampled header are configured for tracing.
- * 
+ *
  * @param {*} ctx The function invocation context.
  * @returns       A ZipkinJS 'TraceId' created from the invocation context.
  */
-function createOCISampler(ctx) {
-  const traceCxt = ctx.traceContext;
-  return new sampler.Sampler((traceId) => traceCxt.isEnabled && !traceCxt.sampled);
+function createOCISampler (ctx) {
+  const traceCxt = ctx.traceContext
+  return new sampler.Sampler((traceId) => traceCxt.isEnabled && !traceCxt.sampled)
 }
 
 /**
- * A helper function to define a Zipkin 'service name' based on the Application 
+ * A helper function to define a Zipkin 'service name' based on the Application
  * and Function being invoked.
- * 
+ *
  * @param {*} ctx The function invocation context.
- * @returns       A well defined service name based on the Application and 
+ * @returns       A well defined service name based on the Application and
  *                Function being invoked.
  */
-function getServiceName(ctx) {
-  const appName = (ctx.appName) ? ctx.appName : 'oci-fn-app';
-  const fnName = (ctx.fnName) ? ctx.fnName : 'oci-fn-node-fdk';
-  return appName + ":" + fnName;
+function getServiceName (ctx) {
+  const appName = (ctx.appName) ? ctx.appName : 'oci-fn-app'
+  const fnName = (ctx.fnName) ? ctx.fnName : 'oci-fn-node-fdk'
+  return appName + ':' + fnName
 }

--- a/examples/tracing-basic/func.js
+++ b/examples/tracing-basic/func.js
@@ -1,0 +1,219 @@
+const fdk=require('@fnproject/fdk');
+
+// ZipkinJS core components.
+const { 
+  ExplicitContext, 
+  Tracer, 
+  TraceId, 
+  BatchRecorder, 
+  jsonEncoder, 
+  sampler, 
+  option
+} = require('zipkin');
+
+// An HTTP transport for dispatching Zipkin traces.
+const {HttpLogger} = require('zipkin-transport-http');
+
+fdk.handle(async function(input, ctx){
+  tracer = createOCITracer(ctx);
+
+  var result;
+  // Start a new 'scoped' server handling span.
+  await tracer.scoped(async function () {
+    // Fetch some resource
+    result = await tracer.local('fetchResource', () => {
+      return fetchResource();
+    });
+    // Perform some processing
+    result = await tracer.local('processResource', () => {
+      return someComputation(result);
+    });
+    // Update some resource
+    result = await tracer.local('updateResource', () => {
+      return updateResource(result);
+    });
+    await flush();
+  }); 
+
+  return result;
+
+})
+
+// ----------------------------------------------------------------------------
+// App Simulation Functions 
+//
+
+/**
+ * Simulate fetching some required resource. This could be another OCI service
+ * or an external call.
+ * 
+ * @returns A Promise with the success or failure of the operation.
+ */
+ function fetchResource() {
+  return simulate(1000, {fetchResource: "OK"});
+}
+
+/**
+ * Simulate some work. This could be another OCI service.
+ * 
+ * @returns A Promise with the success or failure of the operation.
+ */
+async function someComputation(toReturn) {
+  for (i = 0; i < 5; i++) {
+    await simulate(1000);
+  } 
+  toReturn["processResource"] = "OK";
+  return toReturn;
+}
+
+/**
+ * Simulate updating some resource. This could be another OCI service or an 
+ * external call.
+ * 
+ * @returns A Promise with the success or failure of the operation.
+ */
+async function updateResource(toReturn) {
+  await simulate(500);
+  toReturn["updateResource"] = "OK";
+  return toReturn;
+}
+
+/**
+ * A helper function to simulate an operation that takes a specified amount of time.
+ * 
+ * @param {*} ms The simulated time for the activity in milliseconds.
+ * @returns      A promise that resolves when the simulated activity finishes.
+ */
+function simulate(ms, result) {
+  return new Promise(resolve => setTimeout(resolve, ms, result));
+}
+
+/**
+ * Functions service may freeze or terminate the container on completion.
+ * This function gives extra time to allow the runtime to flush any pending traces.
+ * See: https://github.com/openzipkin/zipkin-js/issues/507
+ * 
+ * @returns A Promise to await on.
+ */
+function flush() {
+  return new Promise(resolve => setTimeout(resolve, 1000));
+}
+
+// ----------------------------------------------------------------------------
+// OpenZipkin ZipkinJS Utility Functions 
+//
+
+/**
+ * Creates a basic Zipkin Tracer using values from context of the function 
+ * invocation.
+ * 
+ * @param {*} ctx The function invocation context.
+ * @returns       A configured Tracer for automatically tracing calls.
+ */
+ function createOCITracer(ctx) {
+  const serviceName = getServiceName(ctx);
+
+  // An OCI APM configured Tracer
+  //
+  const traceCxt = ctx.traceContext;
+  const tracer = new Tracer({
+    ctxImpl: new ExplicitContext(),
+    recorder: new BatchRecorder({
+      logger: new HttpLogger({
+        // The configured OCI APM endpoint is available in the function 
+        // invocation context.
+        endpoint: traceCxt.traceCollectorUrl,
+        jsonEncoder: jsonEncoder.JSON_V2
+      }),
+    }),
+    // APM Dimensions that should be included in all traces can be configured 
+    // directly on Tracer.
+    defaultTags: createOCITags(ctx),
+    // A custom sampling strategy can be defined.
+    sampler: createOCISampler(ctx),
+    localServiceName: serviceName,
+    supportsJoin: true,
+    traceId128Bit: true
+  });
+
+  // The initial function invocation trace identifiers can be added directly.
+  // If this is not defined a default TraceId is created.
+  const traceId = createOCITraceId(tracer, ctx);
+  tracer.setId(traceId);
+  return tracer;
+}
+
+/**
+ * A ZipkinJS 'TraceId' can be created directly from the function invocation 
+ * context.
+ * 
+ * @param {*} ctx The function invocation context.
+ * @returns       A ZipkinJS 'TraceId' created from the invocation context.
+ */
+function createOCITraceId(tracer, ctx) {
+  const traceCxt = ctx.traceContext;
+  if (traceCxt.traceId && traceCxt.spanId) {
+    return new TraceId({
+      traceId: traceCxt.traceId,
+      spanId: traceCxt.spanId,
+      sampled: new option.Some(traceCxt.sampled),
+      debug: new option.Some(traceCxt.debug),
+      shared: false
+    });
+  } else {
+    return tracer.createRootId(
+      new option.Some(traceCxt.sampled),
+      new option.Some(traceCxt.debug)
+    );
+  }
+}
+
+/**
+ * A ZipkinJS 'TraceId' can be crated directly from the function invocation 
+ * context.
+ * 
+ * This configurations will automatically add the function meta-data as APM
+ * dimensions to each trace. Function environment variable and other dimensions
+ * could also be added.
+ * 
+ * @param {*} ctx The function invocation context.
+ * @returns       A map of key-value pairs, that will be added as APM 
+ *                dimensions to the traces.
+ */
+function createOCITags(ctx) {
+  return {
+    "appID": ctx.appID,
+    "appName": ctx.appName,
+    "fnID": ctx.fnID,
+    "fnName": ctx.fnName,
+  }
+}
+
+/**
+ * A ZipkinJS 'Sampler' can be created directly from the function invocation 
+ * context. 
+ * 
+ * This configuration will only create a trace if both the function and the 
+ * Zipkin Sampled header are configured for tracing.
+ * 
+ * @param {*} ctx The function invocation context.
+ * @returns       A ZipkinJS 'TraceId' created from the invocation context.
+ */
+function createOCISampler(ctx) {
+  const traceCxt = ctx.traceContext;
+  return new sampler.Sampler((traceId) => traceCxt.isEnabled && !traceCxt.sampled);
+}
+
+/**
+ * A helper function to define a Zipkin 'service name' based on the Application 
+ * and Function being invoked.
+ * 
+ * @param {*} ctx The function invocation context.
+ * @returns       A well defined service name based on the Application and 
+ *                Function being invoked.
+ */
+function getServiceName(ctx) {
+  const appName = (ctx.appName) ? ctx.appName : 'oci-fn-app';
+  const fnName = (ctx.fnName) ? ctx.fnName : 'oci-fn-node-fdk';
+  return appName + ":" + fnName;
+}

--- a/examples/tracing-basic/func.js
+++ b/examples/tracing-basic/func.js
@@ -111,8 +111,6 @@ function flush () {
  * @returns       A configured Tracer for automatically tracing calls.
  */
 function createOCITracer (ctx) {
-  const serviceName = getServiceName(ctx)
-
   // An OCI APM configured Tracer
   //
   const traceCxt = ctx.traceContext
@@ -131,7 +129,7 @@ function createOCITracer (ctx) {
     defaultTags: createOCITags(ctx),
     // A custom sampling strategy can be defined.
     sampler: createOCISampler(ctx),
-    localServiceName: serviceName,
+    localServiceName: traceCxt.serviceName,
     supportsJoin: true,
     traceId128Bit: true
   })
@@ -202,18 +200,4 @@ function createOCITags (ctx) {
 function createOCISampler (ctx) {
   const traceCxt = ctx.traceContext
   return new sampler.Sampler((traceId) => traceCxt.isEnabled && !traceCxt.sampled)
-}
-
-/**
- * A helper function to define a Zipkin 'service name' based on the Application
- * and Function being invoked.
- *
- * @param {*} ctx The function invocation context.
- * @returns       A well defined service name based on the Application and
- *                Function being invoked.
- */
-function getServiceName (ctx) {
-  const appName = (ctx.appName) ? ctx.appName : 'oci-fn-app'
-  const fnName = (ctx.fnName) ? ctx.fnName : 'oci-fn-node-fdk'
-  return (appName + '::' + fnName).toLowerCase()
 }

--- a/examples/tracing-basic/func.yaml
+++ b/examples/tracing-basic/func.yaml
@@ -1,0 +1,5 @@
+schema_version: 20180708
+name: apm-tracing-node-fdk-simple-trace
+version: 0.0.4
+runtime: node
+entrypoint: node func.js

--- a/examples/tracing-basic/package.json
+++ b/examples/tracing-basic/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "apm-tracing-node-fdk-simple-trace",
+	"version": "1.0.0",
+	"description": "Example APM tracing function.",
+	"main": "func.js",
+	"author": "",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@fnproject/fdk": ">=0.0.13",
+		"node-fetch": "^2.6.1",
+		"zipkin": "^0.22.0",
+		"zipkin-transport-http": "^0.22.0"
+	}
+}

--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -397,7 +397,7 @@ class HTTPGatewayContext {
   }
 
   /**
-   * returns the HTTP headers reaceived by the gateway for this event
+   * returns the HTTP headers received by the gateway for this event
    * @returns {*}
    */
   get headers () {
@@ -477,6 +477,7 @@ class TraceContext {
     this.parentSpanId = ctx.getHeader('X-B3-ParentSpanId')
     this.sampled = parseInt(ctx.getHeader('X-B3-Sampled')) === 1
     this.flags = parseInt(ctx.getHeader('X-B3-Flags')) === 1
+    this.serviceName = (ctx.appName + '::' + ctx.fnName).toLowerCase()
   }
 }
 

--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -476,7 +476,7 @@ class TracingContext {
     this.spanId = ctx.getHeader('X-B3-SpanId')
     this.parentSpanId = ctx.getHeader('X-B3-ParentSpanId')
     this.sampled = parseInt(ctx.getHeader('X-B3-Sampled')) === 1
-    this.flags = parseInt(ctx.getHeader('X-B3-Flags')) === 1
+    this.flags = ctx.getHeader('X-B3-Flags')
     this.serviceName = (ctx.appName + '::' + ctx.fnName).toLowerCase()
   }
 }

--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -464,11 +464,11 @@ class HTTPGatewayContext {
 }
 
 /**
- * TraceContext defines an OCI APM tracing context for the current invocation.
+ * TracingContext defines an OCI APM tracing context for the current invocation.
  * Traces are currently defined by the Zipkin standard.
  * See: https://zipkin.io/pages/instrumenting
  */
-class TraceContext {
+class TracingContext {
   constructor (ctx) {
     this.isEnabled = parseInt(ctx._config.OCI_TRACING_ENABLED) === 1
     this.traceCollectorUrl = ctx._config.OCI_TRACE_COLLECTOR_URL
@@ -603,10 +603,10 @@ class Context {
   }
 
   /**
-   * Create an OCI APM TraceContext for the current invocation.
+   * Create an OCI APM TracingContext for the current invocation.
    */
-  get traceContext () {
-    return new TraceContext(this)
+  get tracingContext () {
+    return new TracingContext(this)
   }
 
   /**

--- a/fn-fdk.js
+++ b/fn-fdk.js
@@ -57,7 +57,7 @@ exports.handle = function (fnfunction, options) {
       process.exit(2)
   }
 
- return fdkHandler(fnfunction, options)
+  return fdkHandler(fnfunction, options)
 }
 
 /**
@@ -466,7 +466,7 @@ class HTTPGatewayContext {
 /**
  * TraceContext defines an OCI APM tracing context for the current invocation.
  * Traces are currently defined by the Zipkin standard.
- * See: https://zipkin.io/pages/instrumenting 
+ * See: https://zipkin.io/pages/instrumenting
  */
 class TraceContext {
   constructor (ctx) {
@@ -605,7 +605,7 @@ class Context {
    * Create an OCI APM TraceContext for the current invocation.
    */
   get traceContext () {
-    return new TraceContext(this);
+    return new TraceContext(this)
   }
 
   /**

--- a/test/fn-fdk-test.js
+++ b/test/fn-fdk-test.js
@@ -169,16 +169,16 @@ test('Listens and accepts request', function (t) {
     t.deepEquals(['h1', 'h2'], heads['My-Header'])
     t.deepEquals(['h3'], heads.Otherheader)
 
-    // Should contain the 'defaultSetup'' traceContext.
-    const traceContext = ctx.traceContext
-    t.deepEquals(false, traceContext.isEnabled)
-    t.deepEquals(undefined, traceContext.traceCollectorUrl)
-    t.deepEquals(null, traceContext.traceId)
-    t.deepEquals(null, traceContext.spanId)
-    t.deepEquals(null, traceContext.parentSpanId)
-    t.deepEquals(false, traceContext.sampled)
-    t.deepEquals(false, traceContext.flags)
-    t.deepEquals('appname::fnname', traceContext.serviceName)
+    // Should contain the 'defaultSetup'' tracingContext.
+    const tracingCxt = ctx.tracingContext
+    t.deepEquals(false, tracingCxt.isEnabled)
+    t.deepEquals(undefined, tracingCxt.traceCollectorUrl)
+    t.deepEquals(null, tracingCxt.traceId)
+    t.deepEquals(null, tracingCxt.spanId)
+    t.deepEquals(null, tracingCxt.parentSpanId)
+    t.deepEquals(false, tracingCxt.sampled)
+    t.deepEquals(false, tracingCxt.flags)
+    t.deepEquals('appname::fnname', tracingCxt.serviceName)
 
     ctx.responseContentType = 'text/plain'
 
@@ -239,16 +239,16 @@ test('Listens and accepts tracing request', function (t) {
     t.deepEquals(['h1', 'h2'], heads['My-Header'])
     t.deepEquals(['h3'], heads.Otherheader)
 
-    // Should contain the 'tracingSetup' traceContext.
-    const traceContext = ctx.traceContext
-    t.deepEquals(true, traceContext.isEnabled)
-    t.deepEquals('trace-collector-url', traceContext.traceCollectorUrl)
-    t.deepEquals('canned-trace-id', traceContext.traceId)
-    t.deepEquals('canned-span-id', traceContext.spanId)
-    t.deepEquals('canned-parent-span-id', traceContext.parentSpanId)
-    t.deepEquals(true, traceContext.sampled)
-    t.deepEquals(true, traceContext.flags)
-    t.deepEquals('appname::fnname', traceContext.serviceName)
+    // Should contain the 'tracingSetup' tracingContext.
+    const tracingCxt = ctx.tracingContext
+    t.deepEquals(true, tracingCxt.isEnabled)
+    t.deepEquals('trace-collector-url', tracingCxt.traceCollectorUrl)
+    t.deepEquals('canned-trace-id', tracingCxt.traceId)
+    t.deepEquals('canned-span-id', tracingCxt.spanId)
+    t.deepEquals('canned-parent-span-id', tracingCxt.parentSpanId)
+    t.deepEquals(true, tracingCxt.sampled)
+    t.deepEquals(true, tracingCxt.flags)
+    t.deepEquals('appname::fnname', tracingCxt.serviceName)
 
     ctx.responseContentType = 'text/plain'
 

--- a/test/fn-fdk-test.js
+++ b/test/fn-fdk-test.js
@@ -178,6 +178,7 @@ test('Listens and accepts request', function (t) {
     t.deepEquals(null, traceContext.parentSpanId)
     t.deepEquals(false, traceContext.sampled)
     t.deepEquals(false, traceContext.flags)
+    t.deepEquals('appname::fnname', traceContext.serviceName)
 
     ctx.responseContentType = 'text/plain'
 
@@ -247,6 +248,7 @@ test('Listens and accepts tracing request', function (t) {
     t.deepEquals('canned-parent-span-id', traceContext.parentSpanId)
     t.deepEquals(true, traceContext.sampled)
     t.deepEquals(true, traceContext.flags)
+    t.deepEquals('appname::fnname', traceContext.serviceName)
 
     ctx.responseContentType = 'text/plain'
 

--- a/test/fn-fdk-test.js
+++ b/test/fn-fdk-test.js
@@ -177,7 +177,7 @@ test('Listens and accepts request', function (t) {
     t.deepEquals(null, tracingCxt.spanId)
     t.deepEquals(null, tracingCxt.parentSpanId)
     t.deepEquals(false, tracingCxt.sampled)
-    t.deepEquals(false, tracingCxt.flags)
+    t.deepEquals(null, tracingCxt.flags)
     t.deepEquals('appname::fnname', tracingCxt.serviceName)
 
     ctx.responseContentType = 'text/plain'
@@ -247,7 +247,7 @@ test('Listens and accepts tracing request', function (t) {
     t.deepEquals('canned-span-id', tracingCxt.spanId)
     t.deepEquals('canned-parent-span-id', tracingCxt.parentSpanId)
     t.deepEquals(true, tracingCxt.sampled)
-    t.deepEquals(true, tracingCxt.flags)
+    t.deepEquals('1', tracingCxt.flags)
     t.deepEquals('appname::fnname', tracingCxt.serviceName)
 
     ctx.responseContentType = 'text/plain'


### PR DESCRIPTION
**Overview**

Oracle Functions will soon release a feature providing an integration with the Oracle Application Performance Monitoring (APM) service. This service supports the sending of Zipkin formatted tracing data to a collector endpoint.
The service will provide the function code with data which includes:
- A boolean flag specifying whether the tracing integration is enabled for the function invocation
- A trace collector URL that can be used to configure Zipkin so that tracing data is sent there
- The "B3" formatted headers specifying the originating trace ID and span IDs (as specified by Zipkin)
This information is accessible by the function code in a Tracing Context provided by the FDK.
This change has no effect on existing functions, except that the keys "OCI_TRACING_ENABLED" and "OCI_TRACE_COLLECTOR_URL" are now reserved for this tracing integration and cannot be used for function configuration.


This is a small change to allow a function  to call a tracingContext method on the function invocation context. This method will return a TracingContext that contains the subset of tracing related attributes. These attributes are based on the 'zipkin b3 header set' plus some additional support attributes. This can be used to help set up a Tracer for a function. A simple example has been added for the ZipkinJS library.

This behavior should only be invoked if a developer explicitly calls it from a function. Existing functions should not be affected.

**Features**

* Added mechanism to extract zipkin b3 headers from incoming requests.
* Added a simple tracing example.